### PR TITLE
Support device level power utilization metrics

### DIFF
--- a/sense_energy_prometheus_exporter/sense_energy_prometheus_exporter/client/sense.py
+++ b/sense_energy_prometheus_exporter/sense_energy_prometheus_exporter/client/sense.py
@@ -332,12 +332,16 @@ class SenseClient(object):
                 account.senseable.update_realtime()
                 power = account.senseable.active_power
                 solar_power = account.senseable.active_solar_power
+                active_devices = account.senseable.get_realtime()['devices']
             except Exception as e:
                 logging.error("Unable to retrieve power info from Sense account name %s: %s", account.name, e)
                 continue
 
             powers.append(SensePower.from_api(account.name, "main", power))
             powers.append(SensePower.from_api(account.name, "solar", solar_power))
+
+            for d in active_devices:
+                powers.append(SensePower.from_api(account.name, d['name'], d['w']))
 
         return powers
 


### PR DESCRIPTION
The collector was only exporting the sense_energy_power_watts metric for the
'main' and 'solar' device names. This was only the top-level power consumption
and production. The API does appear to expose realtime power utilization data
for Sense-identified devices on the account, including the Always On and Other
aggregate buckets.

This change enables exporting more 'name' label values for individual device
level utilization on the sense_energy_power_watts metric.

Fixes #3.